### PR TITLE
Ci build issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/src-tauri/src/injection/mod.rs
+++ b/src-tauri/src/injection/mod.rs
@@ -70,11 +70,13 @@ impl TextInjector {
     }
 
     async fn inject_via_keystrokes(&self, text: &str, delay_ms: u64) -> anyhow::Result<()> {
-        let mut enigo = Enigo::new(&Settings::default())
-            .map_err(|e| anyhow::anyhow!("Failed to init enigo: {:?}", e))?;
-        enigo
-            .text(text)
-            .map_err(|e| anyhow::anyhow!("Failed to type text: {:?}", e))?;
+        {
+            let mut enigo = Enigo::new(&Settings::default())
+                .map_err(|e| anyhow::anyhow!("Failed to init enigo: {:?}", e))?;
+            enigo
+                .text(text)
+                .map_err(|e| anyhow::anyhow!("Failed to type text: {:?}", e))?;
+        }
         if delay_ms > 0 {
             sleep(Duration::from_millis(
                 delay_ms.saturating_mul(text.len() as u64),
@@ -111,6 +113,7 @@ impl TextInjector {
         enigo
             .key(modifier, Direction::Release)
             .map_err(|e| anyhow::anyhow!("Failed to release modifier: {:?}", e))?;
+        drop(enigo);
 
         sleep(Duration::from_millis(PASTE_WAIT_MS)).await;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes CI build failures on Ubuntu (missing `libxdo-dev`) and macOS (non-`Send` `enigo::Enigo` across `await`).

The Ubuntu build failed because the `rdev` crate requires `libxdo-dev`, which was not installed in the CI environment. The macOS build failed due to a clippy error where `enigo::Enigo`, which is not `Send` on macOS, was held across `await` points in `inject_via_clipboard` and `inject_via_keystrokes`, preventing the async future from being `Send` as required by `tokio::spawn`.

---
<p><a href="https://cursor.com/agents/bc-f452f011-3d77-4120-a6f5-5808b370acb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f452f011-3d77-4120-a6f5-5808b370acb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->